### PR TITLE
docs: add Windows compatibility instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,27 @@ Here's an example of what you can do when it's connected to Claude.
 
    Or restart Cursor.
 
+### Windows Compatibility
+
+If you're running this project on Windows, be aware that `go-sqlite3` requires **CGO to be enabled** in order to compile and work properly. By default, **CGO is disabled on Windows**, so you need to explicitly enable it and have a C compiler installed.
+
+#### Steps to get it working:
+
+1. **Install a C compiler**  
+   We recommend using [MSYS2](https://www.msys2.org/) to install a C compiler for Windows. After installing MSYS2, make sure to add the `ucrt64\bin` folder to your `PATH`.  
+   → A step-by-step guide is available [here](https://code.visualstudio.com/docs/cpp/config-mingw).
+
+2. **Enable CGO and run the app**  
+
+   ```bash
+   cd whatsapp-bridge
+   go env -w CGO_ENABLED=1
+   go run main.go
+   ```
+
+Without this setup, you'll likely run into errors like:
+> `Binary was compiled with 'CGO_ENABLED=0', go-sqlite3 requires cgo to work.`
+
 ## Architecture Overview
 
 This application consists of two main components:


### PR DESCRIPTION
Just added basic instructions to help run the Go WhatsApp Bridge on Windows. Following these steps, I was able to get the project working inside Claude Desktop.