### PR TITLE
Added support for buttons and list messages in extractTextContent function

### DIFF
--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -167,6 +167,30 @@ func extractTextContent(msg *waProto.Message) string {
 		return extendedText.GetText()
 	}
 
+	var result string
+
+	// Buttons messages
+	if buttons := msg.GetButtonsMessage(); buttons != nil {
+		result += buttons.GetContentText()
+		result += "\n\nButtons:"
+		for _, btn := range buttons.GetButtons() {
+			result += "\n- " + btn.GetButtonText().GetDisplayText()
+		}
+		return result
+	}
+
+	// List messages
+	if list := msg.GetListMessage(); list != nil {
+		result += list.GetDescription()
+		result += "\n\nList:"
+		for _, section := range list.GetSections() {
+			for _, row := range section.GetRows() {
+				result += "\n- " + row.GetTitle() + " — " + row.GetDescription()
+			}
+		}
+		return result
+	}
+
 	// For now, we're ignoring non-text messages
 	return ""
 }


### PR DESCRIPTION
While testing the MCP, I came across business accounts sending more complex message types (like buttons and lists). This is a quick and basic implementation to extract text content from those messages.