### PR TITLE
So it works on Cline

### DIFF
--- a/whatsapp-mcp-server/main.py
+++ b/whatsapp-mcp-server/main.py
@@ -16,7 +16,7 @@ from whatsapp import (
 )
 
 # Initialize FastMCP server
-mcp = FastMCP("whatsapp")
+mcp = FastMCP("whatsapp", log_level="ERROR")
 
 @mcp.tool()
 def search_contacts(query: str) -> List[Dict[str, Any]]:


### PR DESCRIPTION
Without this, logs from other levels are perceived as errors from Cline, preventing the MCP server from being enabled.