### PR TITLE
Add uploads directory to send_file and send_audio_message

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ You can send various media types to your WhatsApp contacts:
   - With FFmpeg installed, the system will automatically convert other audio formats (MP3, WAV, etc.) to the required format.
   - Without FFmpeg, you can still send raw audio files using the `send_file` tool, but they won't appear as playable voice messages.
 
+To configure the media uploads directory, please set the `WHATSAPP_UPLOADS_DIR` environment variable. Default: `[REPOSITORY_ROOT]/uploads`.
+
 #### Media Downloading
 
 By default, just the metadata of the media is stored in the local database. The message will indicate that media was sent. To access this media you need to use the download_media tool which takes the `message_id` and `chat_jid` (which are shown when printing messages containing the meda), this downloads the media and then returns the file path which can be then opened or passed to another tool.

--- a/whatsapp-mcp-server/main.py
+++ b/whatsapp-mcp-server/main.py
@@ -1,3 +1,6 @@
+import os
+from pathlib import Path
+
 from typing import List, Dict, Any, Optional
 from mcp.server.fastmcp import FastMCP
 from whatsapp import (
@@ -14,6 +17,9 @@ from whatsapp import (
     send_audio_message as whatsapp_audio_voice_message,
     download_media as whatsapp_download_media
 )
+
+# Set uploads dir from env var.
+uploads_dir = os.getenv('WHATSAPP_UPLOADS_DIR', default=str(Path(__file__).absolute().parent / '../uploads'))
 
 # Initialize FastMCP server
 mcp = FastMCP("whatsapp")
@@ -197,7 +203,7 @@ def send_file(recipient: str, media_path: str) -> Dict[str, Any]:
     """
     
     # Call the whatsapp_send_file function
-    success, status_message = whatsapp_send_file(recipient, media_path)
+    success, status_message = whatsapp_send_file(recipient, media_path, uploads_dir)
     return {
         "success": success,
         "message": status_message
@@ -215,7 +221,7 @@ def send_audio_message(recipient: str, media_path: str) -> Dict[str, Any]:
     Returns:
         A dictionary containing success status and a status message
     """
-    success, status_message = whatsapp_audio_voice_message(recipient, media_path)
+    success, status_message = whatsapp_audio_voice_message(recipient, media_path, uploads_dir)
     return {
         "success": success,
         "message": status_message


### PR DESCRIPTION
This mitigates the security risk of arbitrary file read triggered by prompt injection when the MCP server is installed in an IDE like Cursor or used by an AI agent. 