### PR TITLE
Fix bug with `list_chats` tool when `include_last_message` is false

### DIFF
--- a/whatsapp-mcp-server/whatsapp.py
+++ b/whatsapp-mcp-server/whatsapp.py
@@ -328,24 +328,32 @@ def list_chats(
         conn = sqlite3.connect(MESSAGES_DB_PATH)
         cursor = conn.cursor()
         
-        # Build base query
-        query_parts = ["""
-            SELECT 
-                chats.jid,
-                chats.name,
-                chats.last_message_time,
-                messages.content as last_message,
-                messages.sender as last_sender,
-                messages.is_from_me as last_is_from_me
-            FROM chats
-        """]
-        
+        # Build base query - conditionally include message fields
         if include_last_message:
-            query_parts.append("""
-                LEFT JOIN messages ON chats.jid = messages.chat_jid 
+            query_parts = ["""
+                SELECT
+                    chats.jid,
+                    chats.name,
+                    chats.last_message_time,
+                    messages.content as last_message,
+                    messages.sender as last_sender,
+                    messages.is_from_me as last_is_from_me
+                FROM chats
+                LEFT JOIN messages ON chats.jid = messages.chat_jid
                 AND chats.last_message_time = messages.timestamp
-            """)
-            
+            """]
+        else:
+            query_parts = ["""
+                SELECT
+                    chats.jid,
+                    chats.name,
+                    chats.last_message_time,
+                    NULL as last_message,
+                    NULL as last_sender,
+                    NULL as last_is_from_me
+                FROM chats
+            """]
+
         where_clauses = []
         params = []
         


### PR DESCRIPTION
## Bug Description
When calling `list_chats()` with `include_last_message=False`, the function was trying to select fields from the messages table without including the necessary JOIN, resulting in an SQL error and no results being returned.

## Fix
Modified the query building logic to use two different SELECT statements based on the value of `include_last_message`:
- When True: includes the JOIN and selects message fields normally
- When False: doesn't include the JOIN and uses NULL placeholders for message fields

This ensures the function works correctly regardless of whether we want to include the last message or not.