### PR TITLE
fix: Unicode-safe chat search + auto-detect business bridge DB

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing
+
+Thank you for your interest in contributing to WhatsApp MCP Server!
+
+## Development Setup
+
+1. Clone the repo and follow the [Installation](README.md#installation) steps.
+2. Python dependencies are managed with [uv](https://github.com/astral-sh/uv):
+   ```bash
+   cd whatsapp-mcp-server
+   uv sync
+   ```
+3. The Go bridge is a standard Go module:
+   ```bash
+   cd whatsapp-bridge
+   go build ./...
+   ```
+
+## Making Changes
+
+- **Python MCP server** lives in `whatsapp-mcp-server/`. Entry point: `main.py`; all DB logic: `whatsapp.py`.
+- **Go bridge** lives in `whatsapp-bridge/`. It stores messages in a local SQLite database at `store/messages.db`.
+- If you run both a personal and a business bridge, the business one goes in `whatsapp-bridge-business/` — the MCP server auto-detects it.
+
+### SQLite Search
+
+All text search in `whatsapp.py` uses `instr()` instead of `LOWER()+LIKE`. Please keep it that way — SQLite's `LOWER()` only handles ASCII, which silently breaks searches in Hebrew, Arabic, CJK, or any non-Latin script.
+
+## Pull Requests
+
+1. Fork the repository and create a branch from `main`.
+2. Keep changes focused — one logical change per PR.
+3. Test against a real WhatsApp session when possible.
+4. Update the README if you change user-visible behaviour or add env vars.
+
+## Reporting Issues
+
+Open a GitHub issue with:
+- What you did
+- What you expected
+- What actually happened
+- Your OS, Go version, and Python version

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Configure the MCP server to point at the right bridge:
 }
 ```
 
-> **Auto-detection:** If `whatsapp-bridge-business/store/messages.db` exists and `WHATSAPP_DB_PATH` is not set, the MCP server automatically uses the business bridge database.
+> **Note:** `WHATSAPP_DB_PATH` must be set explicitly for the business bridge — the default always points to `whatsapp-bridge/store/messages.db` (personal). `WHATSAPP_API_URL` must include the `/api` suffix, e.g. `http://localhost:8742/api`.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,45 @@ By default, just the metadata of the media is stored in the local database. The 
 4. Data flows back through the chain to Claude
 5. When sending messages, the request flows from Claude through the MCP server to the Go bridge and to WhatsApp
 
+## Unicode, Hebrew, and RTL Support
+
+The MCP server fully supports non-Latin scripts (Hebrew, Arabic, CJK, emoji) in both message content and chat names. All search functions (`list_messages`, `list_chats`, `search_contacts`) use SQLite's `instr()` for substring matching rather than `LOWER()+LIKE`, because SQLite's built-in `LOWER()` only handles ASCII — it leaves non-ASCII characters unchanged, which caused silent failures for non-Latin queries.
+
+### Dual-Bridge Setup (Personal + Business)
+
+If you run both a personal and a WhatsApp Business account, you can run two bridge instances side by side:
+
+| Instance | Directory | Default port |
+|----------|-----------|--------------|
+| Personal | `whatsapp-bridge/` | 8741 |
+| Business | `whatsapp-bridge-business/` | 8742 |
+
+Configure each bridge via environment variables:
+
+```bash
+# Business bridge
+WHATSAPP_BRIDGE_PORT=8742 go run main.go
+```
+
+Configure the MCP server to point at the right bridge:
+
+```json
+{
+  "mcpServers": {
+    "whatsapp-business": {
+      "command": "{{PATH_TO_UV}}",
+      "args": ["--directory", "{{PATH_TO_SRC}}/whatsapp-mcp/whatsapp-mcp-server", "run", "main.py"],
+      "env": {
+        "WHATSAPP_DB_PATH": "{{PATH_TO_SRC}}/whatsapp-mcp/whatsapp-bridge-business/store/messages.db",
+        "WHATSAPP_API_URL": "http://localhost:8742/api"
+      }
+    }
+  }
+}
+```
+
+> **Auto-detection:** If `whatsapp-bridge-business/store/messages.db` exists and `WHATSAPP_DB_PATH` is not set, the MCP server automatically uses the business bridge database.
+
 ## Troubleshooting
 
 - If you encounter permission issues when running uv, you may need to add it to your PATH or use the full path to the executable.

--- a/whatsapp-mcp-server/whatsapp.py
+++ b/whatsapp-mcp-server/whatsapp.py
@@ -9,15 +9,10 @@ import audio
 
 import os
 
-def _default_db_path() -> str:
-    base = os.path.dirname(os.path.abspath(__file__))
-    business_db = os.path.normpath(os.path.join(base, '..', 'whatsapp-bridge-business', 'store', 'messages.db'))
-    regular_db = os.path.normpath(os.path.join(base, '..', 'whatsapp-bridge', 'store', 'messages.db'))
-    if os.path.exists(business_db):
-        return business_db
-    return regular_db
-
-MESSAGES_DB_PATH = os.environ.get("WHATSAPP_DB_PATH", _default_db_path())
+MESSAGES_DB_PATH = os.environ.get(
+    "WHATSAPP_DB_PATH",
+    os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'whatsapp-bridge', 'store', 'messages.db'))
+)
 WHATSAPP_API_BASE_URL = os.environ.get("WHATSAPP_API_URL", "http://localhost:8741/api")
 
 @dataclass

--- a/whatsapp-mcp-server/whatsapp.py
+++ b/whatsapp-mcp-server/whatsapp.py
@@ -7,8 +7,18 @@ import requests
 import json
 import audio
 
-MESSAGES_DB_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'whatsapp-bridge', 'store', 'messages.db')
-WHATSAPP_API_BASE_URL = "http://localhost:8080/api"
+import os
+
+def _default_db_path() -> str:
+    base = os.path.dirname(os.path.abspath(__file__))
+    business_db = os.path.normpath(os.path.join(base, '..', 'whatsapp-bridge-business', 'store', 'messages.db'))
+    regular_db = os.path.normpath(os.path.join(base, '..', 'whatsapp-bridge', 'store', 'messages.db'))
+    if os.path.exists(business_db):
+        return business_db
+    return regular_db
+
+MESSAGES_DB_PATH = os.environ.get("WHATSAPP_DB_PATH", _default_db_path())
+WHATSAPP_API_BASE_URL = os.environ.get("WHATSAPP_API_URL", "http://localhost:8741/api")
 
 @dataclass
 class Message:
@@ -350,8 +360,9 @@ def list_chats(
         params = []
         
         if query:
-            where_clauses.append("(LOWER(chats.name) LIKE LOWER(?) OR chats.jid LIKE ?)")
-            params.extend([f"%{query}%", f"%{query}%"])
+            # Use instr() for Unicode-safe substring search (LOWER() only handles ASCII in SQLite)
+            where_clauses.append("(instr(LOWER(chats.name), LOWER(?)) > 0 OR instr(chats.name, ?) > 0 OR chats.jid LIKE ?)")
+            params.extend([query, query, f"%{query}%"])
             
         if where_clauses:
             query_parts.append("WHERE " + " AND ".join(where_clauses))

--- a/whatsapp-mcp-server/whatsapp.py
+++ b/whatsapp-mcp-server/whatsapp.py
@@ -182,8 +182,9 @@ def list_messages(
             params.append(chat_jid)
             
         if query:
-            where_clauses.append("LOWER(messages.content) LIKE LOWER(?)")
-            params.append(f"%{query}%")
+            # instr() is Unicode-safe; LOWER() only handles ASCII in SQLite
+            where_clauses.append("(instr(LOWER(messages.content), LOWER(?)) > 0 OR instr(messages.content, ?) > 0)")
+            params.extend([query, query])
             
         if where_clauses:
             query_parts.append("WHERE " + " AND ".join(where_clauses))
@@ -407,20 +408,17 @@ def search_contacts(query: str) -> List[Contact]:
         conn = sqlite3.connect(MESSAGES_DB_PATH)
         cursor = conn.cursor()
         
-        # Split query into characters to support partial matching
-        search_pattern = '%' +query + '%'
-        
         cursor.execute("""
-            SELECT DISTINCT 
+            SELECT DISTINCT
                 jid,
                 name
             FROM chats
-            WHERE 
-                (LOWER(name) LIKE LOWER(?) OR LOWER(jid) LIKE LOWER(?))
+            WHERE
+                (instr(LOWER(name), LOWER(?)) > 0 OR instr(name, ?) > 0 OR LOWER(jid) LIKE LOWER(?))
                 AND jid NOT LIKE '%@g.us'
             ORDER BY name, jid
             LIMIT 50
-        """, (search_pattern, search_pattern))
+        """, (query, query, f"%{query}%"))
         
         contacts = cursor.fetchall()
         


### PR DESCRIPTION
## Summary

- **Unicode-safe search:** Replaces `LOWER()+LIKE` with `instr()` in all three text-search paths (`list_messages` content, `list_chats` name, `search_contacts` name). SQLite's built-in `LOWER()` only handles ASCII — for Hebrew, Arabic, CJK, and emoji it is a no-op, causing silent failures on non-Latin queries. `instr()` does byte-level substring matching and is reliable for all Unicode.
- **Personal bridge is the default:** `WHATSAPP_DB_PATH` defaults to `whatsapp-bridge/store/messages.db` (the personal bridge). Business users must set `WHATSAPP_DB_PATH` explicitly — there is no auto-detection that could silently redirect both instances to the same database.
- **Dual-bridge docs:** README section explains how to run personal and business bridges side by side with per-instance env vars (`WHATSAPP_DB_PATH`, `WHATSAPP_API_URL`, `WHATSAPP_BRIDGE_PORT`). Clarifies that `WHATSAPP_API_URL` must include the `/api` suffix.
- **CONTRIBUTING.md:** New file covering dev setup, project structure, the `instr()` convention, PR guidelines, and issue reporting.
- **Repo topics:** `whatsapp`, `mcp`, `model-context-protocol`, `whatsapp-api`, `claude`, `sqlite`, `go`, `python`

## What changed in `whatsapp.py`

| Location | Before | After |
|----------|--------|-------|
| `list_messages` content search | `LOWER(content) LIKE LOWER(?)` | `instr(LOWER(content), LOWER(?)) > 0 OR instr(content, ?) > 0` |
| `list_chats` name search | `LOWER(name) LIKE LOWER(?)` | `instr(LOWER(name), LOWER(?)) > 0 OR instr(name, ?) > 0` |
| `search_contacts` name search | `LOWER(name) LIKE LOWER(?)` | `instr(LOWER(name), LOWER(?)) > 0 OR instr(name, ?) > 0` |
| Default DB path | `whatsapp-bridge/store/messages.db` (hardcoded) | Same, via `os.path.normpath` (no auto-detection) |

## Test plan

- [ ] `list_messages(query="תודה")` returns Hebrew-content messages
- [ ] `list_chats(query="מהיום")` finds groups with Hebrew names
- [ ] `search_contacts(query="smith")` still works for ASCII names
- [ ] Personal MCP instance reads `whatsapp-bridge/store/messages.db` by default
- [ ] Business MCP instance reads correct DB when `WHATSAPP_DB_PATH` is set explicitly

🤖 Generated with [Claude Code](https://claude.com/claude-code)