### PR TITLE
security: bind REST API to 127.0.0.1 by default (opt-in LAN via BIND_ADDR)

### DIFF
--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -774,8 +774,17 @@ func startRESTServer(client *whatsmeow.Client, messageStore *MessageStore, port 
 		})
 	})
 
-	// Start the server
-	serverAddr := fmt.Sprintf(":%d", port)
+	// Start the server. Bind to loopback only — the REST API has no auth and
+	// will send WhatsApp messages from the linked account on behalf of any caller.
+	// Binding to all interfaces (":port") would expose send/read to anyone on the
+	// same LAN (home WiFi, café, hotel), so we restrict to 127.0.0.1. The MCP
+	// server connects via http://localhost:{port} (whatsapp-mcp-server/whatsapp.py),
+	// which works unchanged. To opt into LAN exposure, set BIND_ADDR=0.0.0.0.
+	bindAddr := os.Getenv("BIND_ADDR")
+	if bindAddr == "" {
+		bindAddr = "127.0.0.1"
+	}
+	serverAddr := fmt.Sprintf("%s:%d", bindAddr, port)
 	fmt.Printf("Starting REST API server on %s...\n", serverAddr)
 
 	// Run server in a goroutine so it doesn't block


### PR DESCRIPTION
## Summary

The bridge's REST API is bound to all interfaces (`":port"`) and has no authentication, while exposing `send_message` (and media download) for the linked WhatsApp account. On any machine connected to a LAN — home WiFi, office, café, hotel, conference — anyone on that network can hit `<host-ip>:<port>/api/send` and send WhatsApp messages from the linked account without the user knowing.

I caught this on my own setup when a sandboxed automation reached the bridge via `host.docker.internal:8945` and successfully sent a message — at which point I checked `lsof` and realized the same endpoint was reachable from my router's WiFi.

## Fix

One-line behavior change: bind to `127.0.0.1` by default. The MCP server connects via `http://localhost:{port}/api` (`whatsapp-mcp-server/whatsapp.py`), so this is invisible to anyone using the documented MCP setup.

For users who genuinely need LAN access (home automation, multi-host setups), `BIND_ADDR=0.0.0.0` opts back into the previous behavior.

## Test plan

- [x] `go build` succeeds
- [x] Bridge starts on `127.0.0.1:8945` (verified with `lsof -nP -iTCP:8945` → `TCP 127.0.0.1:8945 (LISTEN)` instead of `TCP *:8945`)
- [x] MCP server connects fine (`whatsapp-mcp-server/whatsapp.py` uses `localhost`, unaffected)
- [x] `curl localhost:8945/api/...` → works as before
- [x] `curl <mac-lan-ip>:8945/api/...` from another device on the same WiFi → connection refused (was: 200)
- [x] `BIND_ADDR=0.0.0.0 ./whatsapp-bridge` restores prior behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)