### PR TITLE
feat: add create_group and leave_group MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ Claude can access the following tools to interact with WhatsApp:
 - **send_file**: Send a file (image, video, raw audio, document) to a specified recipient
 - **send_audio_message**: Send an audio file as a WhatsApp voice message (requires the file to be an .ogg opus file or ffmpeg must be installed)
 - **download_media**: Download media from a WhatsApp message and get the local file path
+- **create_group**: Create a new WhatsApp group with the given name and participants (optionally as a community parent or as a sub-group of an existing community)
+- **leave_group**: Leave a WhatsApp group by its JID. WhatsApp's protocol has no "delete group" — leaving is the closest action.
 
 ### Media Handling Features
 

--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -484,6 +484,134 @@ type DownloadMediaResponse struct {
 	Path     string `json:"path,omitempty"`
 }
 
+// CreateGroupRequest represents the request body for the create group API.
+// Participants are bare phone numbers (country code, no '+') or full JIDs.
+// The caller's own JID is added implicitly by WhatsApp — do not include it.
+type CreateGroupRequest struct {
+	Name               string   `json:"name"`
+	Participants       []string `json:"participants"`
+	IsCommunity        bool     `json:"is_community,omitempty"`
+	CommunityParentJID string   `json:"community_parent_jid,omitempty"`
+}
+
+// CreateGroupResponse represents the response for the create group API.
+type CreateGroupResponse struct {
+	Success          bool   `json:"success"`
+	Message          string `json:"message"`
+	JID              string `json:"jid,omitempty"`
+	Name             string `json:"name,omitempty"`
+	ParticipantCount int    `json:"participant_count,omitempty"`
+}
+
+// LeaveGroupRequest represents the request body for the leave group API.
+type LeaveGroupRequest struct {
+	JID string `json:"jid"`
+}
+
+// LeaveGroupResponse represents the response for the leave group API.
+type LeaveGroupResponse struct {
+	Success bool   `json:"success"`
+	Message string `json:"message"`
+}
+
+// createWhatsAppGroup creates a new group on WhatsApp.
+func createWhatsAppGroup(client *whatsmeow.Client, messageStore *MessageStore, req CreateGroupRequest) CreateGroupResponse {
+	if !client.IsConnected() {
+		return CreateGroupResponse{Success: false, Message: "Not connected to WhatsApp"}
+	}
+	if strings.TrimSpace(req.Name) == "" {
+		return CreateGroupResponse{Success: false, Message: "Group name is required"}
+	}
+	// WhatsApp limits group subjects to 25 characters.
+	if len([]rune(req.Name)) > 25 {
+		return CreateGroupResponse{Success: false, Message: "Group name must be 25 characters or fewer"}
+	}
+	if len(req.Participants) == 0 {
+		return CreateGroupResponse{Success: false, Message: "At least one participant is required"}
+	}
+
+	participantJIDs := make([]types.JID, 0, len(req.Participants))
+	for _, p := range req.Participants {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		var jid types.JID
+		var err error
+		if strings.Contains(p, "@") {
+			jid, err = types.ParseJID(p)
+			if err != nil {
+				return CreateGroupResponse{Success: false, Message: fmt.Sprintf("Invalid participant JID %q: %v", p, err)}
+			}
+		} else {
+			jid = types.JID{User: strings.TrimPrefix(p, "+"), Server: "s.whatsapp.net"}
+		}
+		participantJIDs = append(participantJIDs, jid)
+	}
+	if len(participantJIDs) == 0 {
+		return CreateGroupResponse{Success: false, Message: "No valid participants after parsing"}
+	}
+
+	createReq := whatsmeow.ReqCreateGroup{
+		Name:         req.Name,
+		Participants: participantJIDs,
+	}
+	if req.IsCommunity {
+		createReq.GroupParent.IsParent = true
+	}
+	if req.CommunityParentJID != "" {
+		parentJID, err := types.ParseJID(req.CommunityParentJID)
+		if err != nil {
+			return CreateGroupResponse{Success: false, Message: fmt.Sprintf("Invalid community_parent_jid: %v", err)}
+		}
+		createReq.GroupLinkedParent.LinkedParentJID = parentJID
+	}
+
+	groupInfo, err := client.CreateGroup(createReq)
+	if err != nil {
+		return CreateGroupResponse{Success: false, Message: fmt.Sprintf("Error creating group: %v", err)}
+	}
+
+	// Persist the new chat so it shows up in list_chats immediately.
+	createdAt := groupInfo.GroupCreated
+	if createdAt.IsZero() {
+		createdAt = time.Now()
+	}
+	if err := messageStore.StoreChat(groupInfo.JID.String(), groupInfo.Name, createdAt); err != nil {
+		fmt.Printf("Warning: failed to store newly created group chat: %v\n", err)
+	}
+
+	return CreateGroupResponse{
+		Success:          true,
+		Message:          "Group created",
+		JID:              groupInfo.JID.String(),
+		Name:             groupInfo.Name,
+		ParticipantCount: len(groupInfo.Participants),
+	}
+}
+
+// leaveWhatsAppGroup leaves the specified group on WhatsApp.
+func leaveWhatsAppGroup(client *whatsmeow.Client, jidStr string) LeaveGroupResponse {
+	if !client.IsConnected() {
+		return LeaveGroupResponse{Success: false, Message: "Not connected to WhatsApp"}
+	}
+	jidStr = strings.TrimSpace(jidStr)
+	if jidStr == "" {
+		return LeaveGroupResponse{Success: false, Message: "Group JID is required"}
+	}
+	jid, err := types.ParseJID(jidStr)
+	if err != nil {
+		return LeaveGroupResponse{Success: false, Message: fmt.Sprintf("Invalid JID: %v", err)}
+	}
+	if jid.Server != "g.us" {
+		return LeaveGroupResponse{Success: false, Message: "Only group JIDs (@g.us) can be left"}
+	}
+	if err := client.LeaveGroup(jid); err != nil {
+		return LeaveGroupResponse{Success: false, Message: fmt.Sprintf("Error leaving group: %v", err)}
+	}
+	return LeaveGroupResponse{Success: true, Message: fmt.Sprintf("Left group %s", jid.String())}
+}
+
 // Store additional media info in the database
 func (store *MessageStore) StoreMediaInfo(id, chatJID, url string, mediaKey, fileSHA256, fileEncSHA256 []byte, fileLength uint64) error {
 	_, err := store.db.Exec(
@@ -772,6 +900,46 @@ func startRESTServer(client *whatsmeow.Client, messageStore *MessageStore, port 
 			Filename: filename,
 			Path:     path,
 		})
+	})
+
+	// Handler for creating a group
+	http.HandleFunc("/api/create_group", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		var req CreateGroupRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "Invalid request format", http.StatusBadRequest)
+			return
+		}
+		fmt.Printf("Received request to create group %q with %d participants\n", req.Name, len(req.Participants))
+		resp := createWhatsAppGroup(client, messageStore, req)
+		w.Header().Set("Content-Type", "application/json")
+		if !resp.Success {
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+		json.NewEncoder(w).Encode(resp)
+	})
+
+	// Handler for leaving a group
+	http.HandleFunc("/api/leave_group", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		var req LeaveGroupRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "Invalid request format", http.StatusBadRequest)
+			return
+		}
+		fmt.Printf("Received request to leave group %s\n", req.JID)
+		resp := leaveWhatsAppGroup(client, req.JID)
+		w.Header().Set("Content-Type", "application/json")
+		if !resp.Success {
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+		json.NewEncoder(w).Encode(resp)
 	})
 
 	// Start the server

--- a/whatsapp-mcp-server/main.py
+++ b/whatsapp-mcp-server/main.py
@@ -12,7 +12,9 @@ from whatsapp import (
     send_message as whatsapp_send_message,
     send_file as whatsapp_send_file,
     send_audio_message as whatsapp_audio_voice_message,
-    download_media as whatsapp_download_media
+    download_media as whatsapp_download_media,
+    create_group as whatsapp_create_group,
+    leave_group as whatsapp_leave_group
 )
 
 # Initialize FastMCP server
@@ -245,6 +247,56 @@ def download_media(message_id: str, chat_jid: str) -> Dict[str, Any]:
             "success": False,
             "message": "Failed to download media"
         }
+
+@mcp.tool()
+def create_group(
+    name: str,
+    participants: List[str],
+    is_community: bool = False,
+    community_parent_jid: str = "",
+) -> Dict[str, Any]:
+    """Create a new WhatsApp group.
+
+    Args:
+        name: Group subject (max 25 characters per WhatsApp's limit)
+        participants: List of phone numbers (country code, no '+') or JIDs
+                      (e.g., "919866457501" or "919866457501@s.whatsapp.net").
+                      Your own number is added automatically — do not include it.
+        is_community: If True, create a community parent instead of a normal group
+        community_parent_jid: If set, create this group as a sub-group inside the
+                              given community (mutually exclusive with is_community)
+
+    Returns:
+        Dict with: success (bool), message (str), and on success: jid, name,
+        participant_count.
+    """
+    success, message, details = whatsapp_create_group(
+        name=name,
+        participants=participants,
+        is_community=is_community,
+        community_parent_jid=community_parent_jid,
+    )
+    response: Dict[str, Any] = {"success": success, "message": message}
+    if success and details:
+        response.update(details)
+    return response
+
+
+@mcp.tool()
+def leave_group(jid: str) -> Dict[str, Any]:
+    """Leave a WhatsApp group. Note: WhatsApp has no 'delete group' — leaving is
+    the closest action. Other members will see "<you> left" and the group remains
+    on their side.
+
+    Args:
+        jid: The group JID (must end with @g.us, e.g. "120363426272007458@g.us")
+
+    Returns:
+        Dict with success (bool) and message (str).
+    """
+    success, message = whatsapp_leave_group(jid)
+    return {"success": success, "message": message}
+
 
 if __name__ == "__main__":
     # Initialize and run the server

--- a/whatsapp-mcp-server/whatsapp.py
+++ b/whatsapp-mcp-server/whatsapp.py
@@ -724,6 +724,64 @@ def send_audio_message(recipient: str, media_path: str) -> Tuple[bool, str]:
     except Exception as e:
         return False, f"Unexpected error: {str(e)}"
 
+def create_group(
+    name: str,
+    participants: List[str],
+    is_community: bool = False,
+    community_parent_jid: str = "",
+) -> Tuple[bool, str, Optional[dict]]:
+    try:
+        if not name or not name.strip():
+            return False, "Group name is required", None
+        if not participants:
+            return False, "At least one participant is required", None
+
+        url = f"{WHATSAPP_API_BASE_URL}/create_group"
+        payload = {
+            "name": name,
+            "participants": participants,
+            "is_community": is_community,
+            "community_parent_jid": community_parent_jid,
+        }
+
+        response = requests.post(url, json=payload)
+        try:
+            result = response.json()
+        except json.JSONDecodeError:
+            return False, f"Error parsing response: {response.text}", None
+
+        success = bool(result.get("success", False))
+        message = result.get("message", "Unknown response")
+        details = {
+            "jid": result.get("jid"),
+            "name": result.get("name"),
+            "participant_count": result.get("participant_count"),
+        } if success else None
+        return success, message, details
+
+    except requests.RequestException as e:
+        return False, f"Request error: {str(e)}", None
+    except Exception as e:
+        return False, f"Unexpected error: {str(e)}", None
+
+
+def leave_group(jid: str) -> Tuple[bool, str]:
+    try:
+        if not jid or not jid.strip():
+            return False, "Group JID is required"
+        url = f"{WHATSAPP_API_BASE_URL}/leave_group"
+        response = requests.post(url, json={"jid": jid})
+        try:
+            result = response.json()
+        except json.JSONDecodeError:
+            return False, f"Error parsing response: {response.text}"
+        return bool(result.get("success", False)), result.get("message", "Unknown response")
+    except requests.RequestException as e:
+        return False, f"Request error: {str(e)}"
+    except Exception as e:
+        return False, f"Unexpected error: {str(e)}"
+
+
 def download_media(message_id: str, chat_jid: str) -> Optional[str]:
     """Download media from a message and return the local file path.
     


### PR DESCRIPTION
## Summary

Adds two new MCP tools so the agent can manage groups, not just read/send into existing ones.

- **`create_group(name, participants, is_community=False, community_parent_jid="")`** — wraps `whatsmeow.CreateGroup`. Participants accept either bare phone numbers (country code, no `+`) or full JIDs. The caller's own JID is added implicitly by WhatsApp, so it must not be included. Optionally creates a community parent (`is_community=True`) or attaches the new group as a sub-group of an existing community (`community_parent_jid`). Persists the resulting chat to the local SQLite so it shows up in `list_chats` right away.
- **`leave_group(jid)`** — wraps `whatsmeow.LeaveGroup`. WhatsApp has no "delete group" primitive — this is the closest action; other members continue to see the group with you marked as left.

## Changes

- `whatsapp-bridge/main.go`: new `/api/create_group` and `/api/leave_group` endpoints + their request/response types and handlers.
- `whatsapp-mcp-server/whatsapp.py`: matching `create_group` / `leave_group` HTTP helpers.
- `whatsapp-mcp-server/main.py`: tool registrations.
- `README.md`: tool list updated with the two new entries.

No dependency bumps. No changes to existing tools or storage schema. Builds cleanly against the whatsmeow version pinned in `go.mod`.

## Test plan

- [x] `go build` clean against the existing pinned whatsmeow.
- [x] `python3 -m py_compile` clean on both server files.
- [x] Manually exercised on a live bridge: created a 2-person group via `POST /api/create_group`, confirmed it appeared in WhatsApp on both ends and in `list_chats`. Then left it via `POST /api/leave_group` and confirmed the "left" event on the other device.
- [ ] Reviewer to verify behaviour against their own paired account.

## Notes / open questions

- I deliberately kept the surface minimal (just `name`, `participants`, plus the two community knobs that `whatsmeow.ReqCreateGroup` already exposes here). Happy to add `announce`/`locked`/`ephemeral`/`join_approval_required` in a follow-up — they need a newer whatsmeow than the one currently pinned.
- `create_group` writes the new chat row directly to the bridge SQLite. WhatsApp's own `events.JoinedGroup` would also do this asynchronously; doing it eagerly just makes the tool's response immediately visible to subsequent `list_chats` calls in the same MCP session. Open to dropping that line if you'd rather rely on the event path alone.
- Group names are silently capped by WhatsApp at 25 chars — I validate this client-side in the bridge and return a clear error rather than letting whatsmeow surface a 406.

🤖 Generated with [Claude Code](https://claude.com/claude-code)