### PR TITLE
fix: set explicit mime + FileName on document uploads

### DIFF
--- a/whatsapp-bridge/main.go
+++ b/whatsapp-bridge/main.go
@@ -276,7 +276,45 @@ func sendWhatsAppMessage(client *whatsmeow.Client, recipient string, message str
 			mediaType = whatsmeow.MediaVideo
 			mimeType = "video/quicktime"
 
-		// Document types (for any other file type)
+		// Document types — explicit mimes for the common ones, octet-stream as last resort.
+		// WhatsApp displays "fichier non reconnu" without the right mime, even though the
+		// file would otherwise open fine.
+		case "pdf":
+			mediaType = whatsmeow.MediaDocument
+			mimeType = "application/pdf"
+		case "doc":
+			mediaType = whatsmeow.MediaDocument
+			mimeType = "application/msword"
+		case "docx":
+			mediaType = whatsmeow.MediaDocument
+			mimeType = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+		case "xls":
+			mediaType = whatsmeow.MediaDocument
+			mimeType = "application/vnd.ms-excel"
+		case "xlsx":
+			mediaType = whatsmeow.MediaDocument
+			mimeType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+		case "ppt":
+			mediaType = whatsmeow.MediaDocument
+			mimeType = "application/vnd.ms-powerpoint"
+		case "pptx":
+			mediaType = whatsmeow.MediaDocument
+			mimeType = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+		case "odt":
+			mediaType = whatsmeow.MediaDocument
+			mimeType = "application/vnd.oasis.opendocument.text"
+		case "ods":
+			mediaType = whatsmeow.MediaDocument
+			mimeType = "application/vnd.oasis.opendocument.spreadsheet"
+		case "txt":
+			mediaType = whatsmeow.MediaDocument
+			mimeType = "text/plain"
+		case "csv":
+			mediaType = whatsmeow.MediaDocument
+			mimeType = "text/csv"
+		case "zip":
+			mediaType = whatsmeow.MediaDocument
+			mimeType = "application/zip"
 		default:
 			mediaType = whatsmeow.MediaDocument
 			mimeType = "application/octet-stream"
@@ -345,8 +383,10 @@ func sendWhatsAppMessage(client *whatsmeow.Client, recipient string, message str
 				FileLength:    &resp.FileLength,
 			}
 		case whatsmeow.MediaDocument:
+			docFilename := filepath.Base(mediaPath)
 			msg.DocumentMessage = &waProto.DocumentMessage{
-				Title:         proto.String(mediaPath[strings.LastIndex(mediaPath, "/")+1:]),
+				FileName:      proto.String(docFilename),
+				Title:         proto.String(docFilename),
 				Caption:       proto.String(message),
 				Mimetype:      proto.String(mimeType),
 				URL:           &resp.URL,


### PR DESCRIPTION
## Summary
- Without an explicit mime, WhatsApp shows "fichier non reconnu" on the recipient side even though the file opens fine when downloaded.
- Add per-extension mappings for the common office/text/archive formats: pdf, doc(x), xls(x), ppt(x), odt, ods, txt, csv, zip. Anything else still falls back to \`application/octet-stream\`.
- Set \`FileName\` on \`DocumentMessage\` (in addition to \`Title\`) so the recipient sees the original filename rather than the proto's display title alone.

## Test plan
- [x] Send a PDF: arrives as a proper PDF (preview, "Open in viewer") instead of "fichier non reconnu"
- [x] Send a .docx / .xlsx: opens in the right app, no warning
- [x] Send an unknown extension (e.g. \`.foo\`): falls back to \`application/octet-stream\`, still delivered as a generic document
- [x] Verify the recipient sees the original filename (not just a generic title)