### PR TITLE
Ignore the compiled bridge binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 *.db
 claude_desktop_config.json
 whatsapp.log
+
+# Compiled bridge binary. `go build` names it after the module
+# (whatsapp-client); building it as a service names it whatsapp-bridge.
+whatsapp-bridge/whatsapp-client
+whatsapp-bridge/whatsapp-bridge


### PR DESCRIPTION
Running the bridge as a background service requires `go build`, which leaves a binary in `whatsapp-bridge/`. It shows up as untracked and is easy to sweep into a commit with `git add -A`.

The README only documents `go run main.go`, which compiles to a temporary directory, so the artefact never appeared while that was the only documented path.

Both names are covered:

- `go build` names the binary after the module, so it lands as `whatsapp-client`
- a service install builds it explicitly as `whatsapp-bridge`

One file, four lines added. No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J7hMPKheK9gNDcMSZdHGrv